### PR TITLE
edit

### DIFF
--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -8,7 +8,7 @@
         <li class="footer-item">
           <a
             class="footer-item-link line"
-            href="https://www.instagram.com/goitclub/ "
+            href="https://www.instagram.com/goitclub/"
             target="_blank"
             rel="noopener noreferrer"
             >Instagram</a


### PR DESCRIPTION
## Summary by Sourcery

Fix the Instagram link in the footer by removing an extra space at the end of the URL.